### PR TITLE
display pair timestamps on fcd page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2021-06-10
+
+### Added
+
+- FCD page now displays pair timestamps
+
 ## [0.7.1] - 2021-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taurus",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/FirstClassData/FirstClassData.js
+++ b/src/components/FirstClassData/FirstClassData.js
@@ -5,6 +5,8 @@ import { Grid, Text, Heading, Card, CardHeader, CardBody } from "grommet";
 import { truncate, keyToHex } from "@Formatters";
 import { KeyValuePairs, LoadingState, SearchBar } from "@Ui";
 
+import { formatTimestamp } from "@Utils";
+
 import { fetchFCD } from "@Services";
 import { isEmpty } from "ramda";
 
@@ -61,7 +63,7 @@ function FirstClassData() {
               gridGap: "24px 12px",
             }}
           >
-            {displayedItems.map(({ _id: key, value }) => (
+            {displayedItems.map(({ _id: key, value, dataTimestamp }) => (
               <Card key={key} style={{ minHeight: "172px" }}>
                 <CardHeader
                   pad="small"
@@ -96,6 +98,10 @@ function FirstClassData() {
                       {
                         key: "value",
                         value: value,
+                      },
+                      {
+                        key: "timestamp",
+                        value: formatTimestamp(dataTimestamp),
                       },
                     ]}
                   />


### PR DESCRIPTION
Updated FCD cards to display timestamps:

![image](https://user-images.githubusercontent.com/47114840/121537964-ca5bcf00-c9da-11eb-89c8-cad523d940ad.png)
