### PR TITLE
display pair timestamps on l2d related pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3] - 2021-06-10
+
+### Added
+
+- L2D page and Leaf details on Block modal now display pair timestamps
+
 ## [0.7.2] - 2021-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taurus",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/Block/Block.js
+++ b/src/components/Block/Block.js
@@ -13,7 +13,7 @@ const propTypes = {
 };
 
 function Block({ block }) {
-  const { blockId, root, votes, chainAddress } = block;
+  const { blockId, root, votes, chainAddress, dataTimestamp } = block;
 
   const [isLoading, setIsLoading] = useState(true);
   const [leaves, setLeaves] = useState();
@@ -71,6 +71,7 @@ function Block({ block }) {
         <LeavesTable
           blockId={blockId}
           chainAddress={chainAddress}
+          timestamp={dataTimestamp}
           leaves={numericSortByAttribute(leaves)}
           isLoading={isLoading}
         />

--- a/src/components/Block/Leaf.js
+++ b/src/components/Block/Leaf.js
@@ -21,6 +21,7 @@ import { isSizeMobile } from "@Utils";
 const propTypes = {
   leaf: PropTypes.object.isRequired,
   blockId: PropTypes.number.isRequired,
+  timestamp: PropTypes.string.isRequired,
   label: PropTypes.string,
   chainAddress: PropTypes.string.isRequired,
 };
@@ -29,7 +30,7 @@ const defaultProps = {
   label: undefined,
 };
 
-function Leaf({ leaf, blockId, label, chainAddress }) {
+function Leaf({ leaf, blockId, label, chainAddress, timestamp }) {
   const { key, proof, value } = leaf;
   const [show, setShow] = useState(false);
 
@@ -93,6 +94,7 @@ function Leaf({ leaf, blockId, label, chainAddress }) {
                 proof={proof}
                 value={value}
                 chainAddress={chainAddress}
+                timestamp={timestamp}
               />
             </Box>
             <Box>

--- a/src/components/Block/LeavesTable.js
+++ b/src/components/Block/LeavesTable.js
@@ -14,17 +14,23 @@ import "./leavesTable.scss";
 const propTypes = {
   leaves: PropTypes.array.isRequired,
   blockId: PropTypes.number.isRequired,
+  timestamp: PropTypes.string.isRequired,
   chainAddress: PropTypes.string.isRequired,
   isLoading: PropTypes.bool.isRequired,
 };
 
-function LeavesTable({ leaves, blockId, chainAddress, isLoading }) {
+function LeavesTable({ leaves, blockId, chainAddress, isLoading, timestamp }) {
   const properties = [
     {
       property: "key",
       primary: true,
       render: (datum) => (
-        <Leaf blockId={blockId} chainAddress={chainAddress} leaf={datum} />
+        <Leaf
+          blockId={blockId}
+          chainAddress={chainAddress}
+          leaf={datum}
+          timestamp={timestamp}
+        />
       ),
     },
     { property: "value", render: ({ value }) => valueToString(value) },

--- a/src/components/LayerTwoData/Proof.js
+++ b/src/components/LayerTwoData/Proof.js
@@ -25,7 +25,7 @@ const defaultProps = {
 
 function Proof({ proof, leaveKey, value, priceName, block }) {
   return (
-    <Card style={{ height: "252px" }}>
+    <Card style={{ height: "302px" }}>
       <CardHeader
         pad="small"
         justify="center"
@@ -43,6 +43,7 @@ function Proof({ proof, leaveKey, value, priceName, block }) {
           proof={proof}
           value={value}
           chainAddress={block.chainAddress}
+          timestamp={block.dataTimestamp}
         />
       </CardBody>
     </Card>

--- a/src/components/ui/KeyValuePairs/LeafPairs.js
+++ b/src/components/ui/KeyValuePairs/LeafPairs.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import KeyValuePairs from "./KeyValuePairs";
 
+import { formatTimestamp } from "@Utils";
 import { truncate, keyToHex, valueToString } from "@Formatters";
 
 const propTypes = {
@@ -16,9 +17,17 @@ const propTypes = {
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   chainAddress: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
     .isRequired,
+  timestamp: PropTypes.string.isRequired,
 };
 
-function LeafPairs({ leafKey, blockId, proof, value, chainAddress }) {
+function LeafPairs({
+  leafKey,
+  blockId,
+  proof,
+  value,
+  chainAddress,
+  timestamp,
+}) {
   return (
     <>
       <KeyValuePairs
@@ -47,6 +56,10 @@ function LeafPairs({ leafKey, blockId, proof, value, chainAddress }) {
             key: "block ID",
             value: blockId,
             clipboardable: true,
+          },
+          {
+            key: "timestamp",
+            value: formatTimestamp(timestamp),
           },
           {
             key: "chain address",


### PR DESCRIPTION
This updates the properties list of pages related to L2D.

- Leaf data inside blocks details

Before:
![image](https://user-images.githubusercontent.com/47114840/121578594-36e9c480-ca01-11eb-8b06-f1c1f54bb91e.png)

After:
![image](https://user-images.githubusercontent.com/47114840/121578649-4701a400-ca01-11eb-9305-430e54f2fff5.png)

- L2D page

Before:
![image](https://user-images.githubusercontent.com/47114840/121578747-613b8200-ca01-11eb-92c3-4e91d0417c76.png)

After:
![image](https://user-images.githubusercontent.com/47114840/121578784-6b5d8080-ca01-11eb-8168-f1eca7dd5b38.png)
